### PR TITLE
Add drag and drop sorting for sidebar items

### DIFF
--- a/src/components/sidebar-dialog-preview.ts
+++ b/src/components/sidebar-dialog-preview.ts
@@ -43,17 +43,14 @@ export class SidebarDialogPreview extends LitElement {
     if (_changedProperties.has('_paperListbox') && this._paperListbox) {
       this._ready = true;
     }
+
     if (_changedProperties.has('_sidebarConfig') && this._sidebarConfig) {
       const oldConfig = _changedProperties.get('_sidebarConfig') as SidebarConfig | undefined;
       const newConfig = this._sidebarConfig;
 
       if (oldConfig && JSON.stringify(oldConfig) !== JSON.stringify(newConfig)) {
         console.log('Config changed', JSON.stringify(oldConfig) !== JSON.stringify(newConfig));
-        this._ready = false;
-        this._paperListbox = getPreviewItems(this.hass, newConfig);
-        if (this._paperListbox) {
-          this._ready = true;
-        }
+        this._updateListbox(newConfig);
       }
     }
 
@@ -62,6 +59,17 @@ export class SidebarDialogPreview extends LitElement {
       setTimeout(() => {
         this._getDefaultColors();
       }, 100);
+    }
+  }
+
+  public _updateListbox(newConfig?: SidebarConfig): void {
+    if (!newConfig) {
+      newConfig = this._sidebarConfig;
+    }
+    this._ready = false;
+    this._paperListbox = getPreviewItems(this.hass, newConfig);
+    if (this._paperListbox) {
+      this._ready = true;
     }
   }
 

--- a/src/components/sidebar-dialog.ts
+++ b/src/components/sidebar-dialog.ts
@@ -118,9 +118,9 @@ export class SidebarConfigDialog extends LitElement {
   }
 
   private _renderSidebarPreview(): TemplateResult {
-    if (!this._sidebarConfig || !this._configLoaded) {
-      return html`<ha-circular-progress .indeterminate=${true} .size=${'medium'}></ha-circular-progress>`;
-    }
+    // if (!this._sidebarConfig || !this._configLoaded) {
+    //   return html`<ha-circular-progress .indeterminate=${true} .size=${'medium'}></ha-circular-progress>`;
+    // }
 
     return html`
       <div id="sidebar-preview">


### PR DESCRIPTION
Implement drag and drop functionality to allow users to sort items within the sidebar. This enhances the user experience by providing a more interactive way to manage item order.

![2025-04-19 00 22 31](https://github.com/user-attachments/assets/0066bc45-8e96-457d-8e85-dd8f534f82b5)
