### PR TITLE
fix: hide notification badge when template returns empty/whitespace value

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1132,8 +1132,7 @@ class SidebarOrganizer {
     }
 
     const callback = (resultContent: any) => {
-      if (resultContent) {
-        // console.log('Notification:', resultContent);
+      if (resultContent != null && String(resultContent).trim() !== '') {
         if (typeof resultContent === 'string' && isIcon(resultContent)) {
           badge.remove();
           notifyIcon.setAttribute('icon', resultContent);
@@ -1146,10 +1145,9 @@ class SidebarOrganizer {
         }
         panel.setAttribute(ATTRIBUTE.DATA_NOTIFICATION, 'true');
       } else {
-        notifyIcon.removeAttribute('icon');
-        badge.innerHTML = '';
-        badge.classList.toggle(CLASS.NO_VISIBLE, true);
-        // panel.removeAttribute(ATTRIBUTE.DATA_NOTIFICATION);
+        notifyIcon.remove();
+        badge.remove();
+        panel.removeAttribute(ATTRIBUTE.DATA_NOTIFICATION);
       }
     };
     this._subscribeTemplate(value, callback);


### PR DESCRIPTION
## Problem

When using notification templates that return an empty string (e.g., to hide the badge when there are no alerts), the badge still displays as visible. 

The CSS-based hiding using the `NO_VISIBLE` class only works when `data-notification='true'` is set on the parent element, but this attribute is only set in the "show" branch - never in the "hide" branch. So the badge remains visible even with the `no-visible` class applied.

<img width="312" height="109" alt="image" src="https://github.com/user-attachments/assets/4db00432-723b-45bc-8db1-81f37832f15c" />

## Solution

- Changed the "hide" branch to actually remove the badge elements instead of relying on CSS class toggling
- Improved the condition to properly handle empty/whitespace strings: `if (resultContent != null && String(resultContent).trim() !== '')`

<img width="286" height="102" alt="image" src="https://github.com/user-attachments/assets/a0e90640-e646-4f5a-9a89-d07b460edd3b" />

<img width="263" height="95" alt="image" src="https://github.com/user-attachments/assets/7e54eb2b-0bdd-4b2a-b3fb-24c7393be829" />


## Example use case

```yaml
notification:
  alerts-dashboard: >-
    {{ states('sensor.alert_count') if states('sensor.alert_count') | int(0) > 0 else "" }}
