### PR TITLE
fix: properly hide notification badges when empty

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1237,33 +1237,41 @@ export class SidebarOrganizer {
     if (!badge || !notifyIcon) {
       badge = document.createElement('span');
       badge.classList.add(CLASS.BADGE);
+      badge.classList.add(CLASS.NO_VISIBLE); // Start hidden
       badge.setAttribute(ATTRIBUTE.SLOT, 'end');
       notifyIcon = document.createElement('ha-icon');
       notifyIcon.classList.add(CLASS.BADGE);
+      notifyIcon.classList.add(CLASS.NO_VISIBLE); // Start hidden
       notifyIcon.setAttribute(ATTRIBUTE.SLOT, 'end');
       panel.insertBefore(badge, itemText.nextElementSibling);
       panel.insertBefore(notifyIcon, itemText);
+      panel.setAttribute(ATTRIBUTE.DATA_NOTIFICATION, 'true');
     }
 
     const callback = (resultContent: any) => {
-      if (resultContent) {
-        // console.log('Notification:', resultContent);
+      // Check for non-empty values (handle null, undefined, empty strings, whitespace-only)
+      if (resultContent != null && String(resultContent).trim() !== '') {
         if (typeof resultContent === 'string' && isIcon(resultContent)) {
-          badge.remove();
+          // Show icon, hide badge
+          badge.innerHTML = '';
+          notifyIcon.classList.toggle(CLASS.NO_VISIBLE, false);
           notifyIcon.setAttribute('icon', resultContent);
+          badge.classList.toggle(CLASS.NO_VISIBLE, true);
         } else {
-          notifyIcon.remove();
+          // Show badge, hide icon
           badge.innerHTML = resultContent;
           badge.classList.toggle(CLASS.NO_VISIBLE, false);
           badge.classList.toggle(CLASS.BADGE_NUMBER, !isNaN(resultContent));
           badge.classList.toggle(CLASS.LARGE_BADGE, resultContent.length >= 3);
+          notifyIcon.classList.toggle(CLASS.NO_VISIBLE, true);
+          notifyIcon.removeAttribute('icon');
         }
-        panel.setAttribute(ATTRIBUTE.DATA_NOTIFICATION, 'true');
       } else {
+        // Hide both elements when no value
+        notifyIcon.classList.toggle(CLASS.NO_VISIBLE, true);
         notifyIcon.removeAttribute('icon');
         badge.innerHTML = '';
         badge.classList.toggle(CLASS.NO_VISIBLE, true);
-        // panel.removeAttribute(ATTRIBUTE.DATA_NOTIFICATION);
       }
     };
     this._subscribeTemplate(value, callback);


### PR DESCRIPTION
## Problem

When notification templates return an empty string (intended to hide the badge when there are no alerts), the badges still appear as visible broken lines instead of being completely hidden.

<img width="312" height="109" alt="image" src="https://github.com/user-attachments/assets/4db00432-723b-45bc-8db1-81f37832f15c" />

This creates visual clutter and makes it appear as though notifications are present when they shouldn't be visible.

## Solution

This fix ensures badges are properly hidden when templates return empty values:

- **Initialize badges as hidden**: When notification badges are created, they now start with the hidden state, preventing empty badges from appearing on initial page load
- **Set required CSS attributes on creation**: The `data-notification` attribute is now set when badges are created, ensuring the CSS hiding rules work correctly from the start
- **Improved empty detection**: Enhanced the condition to properly detect empty values including null, undefined, and whitespace-only strings
- **Use CSS visibility toggling**: Badges now use CSS class toggling to show/hide, maintaining consistent behavior across all state changes (empty, number, icon)

After the fix, badges are completely hidden when empty and appear properly when they have content:

<img width="286" height="102" alt="image" src="https://github.com/user-attachments/assets/a0e90640-e646-4f5a-9a89-d07b460edd3b" />

<img width="263" height="95" alt="image" src="https://github.com/user-attachments/assets/7e54eb2b-0bdd-4b2a-b3fb-24c7393be829" />

## Example use case

```yaml
notification:
  alerts-dashboard: >-
    {{ states('sensor.alert_count') if states('sensor.alert_count') | int(0) > 0 else "" }}