### PR TITLE
Add scroll hide header functionality

### DIFF
--- a/src/constants/dom.ts
+++ b/src/constants/dom.ts
@@ -31,6 +31,7 @@ export enum SELECTOR {
   SETTINGS_ITEM = 'ha-md-list-item[href="/config"]',
   CONTENT = '.content',
   SIDEBAR_LOADER = 'ha-fade-in',
+  HUI_ROOT = 'hui-root',
 }
 export enum ELEMENT {
   ITEM = 'ha-md-list-item',
@@ -55,6 +56,7 @@ export enum ELEMENT {
   PROFILE_GENERAL = 'ha-profile-section-general',
   SO_PROFILE_SECTION = 'so-profile-section',
   CONFIG_LOVELACE_DASHBOARDS = 'ha-config-lovelace-dashboards',
+  HA_PANEL_LOVELACE = 'ha-panel-lovelace',
 }
 
 export enum CLASS {

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -295,3 +295,31 @@ export const DRAWER_STYLE = css`
     background-color: transparent;
   }
 `;
+
+export const HUI_ROOT_STYLE = css`
+  :host .header::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: var(--header-hide-progress, 0);
+    background: linear-gradient(180deg, var(--primary-background-color, rgba(0, 0, 0, 0.5)) 0%, transparent 100%);
+    transition: opacity 0.3s ease;
+  }
+
+  :host .header .toolbar {
+    will-change: transform, opacity;
+
+    transition:
+      transform 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045),
+      opacity 0.25s linear;
+  }
+
+  :host .header.scroll-hide,
+  :host([scrolled]) .header.scroll-hide {
+    box-shadow: none !important;
+    background: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+`;

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -53,7 +53,7 @@ import { HAElement, HAQuerySelector, HAQuerySelectorEvent, OnListenDetail } from
 import { HomeAssistantStylesManager } from 'home-assistant-styles-manager';
 
 import { SoGroupDivider } from './components/so-group-divider';
-import { DIVIDER_ADDED_STYLE, DRAWER_STYLE } from './sidebar-css';
+import { DIVIDER_ADDED_STYLE, DRAWER_STYLE, HUI_ROOT_STYLE } from './sidebar-css';
 
 export class SidebarOrganizer {
   constructor() {
@@ -214,6 +214,83 @@ export class SidebarOrganizer {
     }
   }
 
+  // This function is only for personal use, not mentioned in the readme as it is not a core part of the plugin.
+  // It adds a scroll listener to the lovelace panel to hide the header when scrolling down and show it when scrolling up.
+  // Set 'scroll_hide_header: true' in config to enable it.
+
+  private _onWindowScrollHideHeader?: () => void;
+  private async _watchScrollHideHeader() {
+    if (!this._config.scroll_hide_header) return;
+    const panelResolver = (await this._panelResolver.element) as PartialPanelResolver;
+    const panelLovelace = panelResolver.querySelector(ELEMENT.HA_PANEL_LOVELACE) as HTMLElement | null;
+    if (!panelLovelace) return;
+    const huiRoot = panelLovelace?.shadowRoot?.querySelector(SELECTOR.HUI_ROOT) as HTMLElement | null;
+    if (!huiRoot?.shadowRoot) return;
+    console.debug('watch scroll from panel loaded event', { panelLovelace, huiRoot });
+    this._styleManager.addStyle([HUI_ROOT_STYLE.toString()], huiRoot.shadowRoot);
+
+    const header = huiRoot.shadowRoot.querySelector('.header') as HTMLElement | null;
+    const toolbar = header?.querySelector('.toolbar') as HTMLElement | null;
+    if (!header || !toolbar) return;
+
+    const maxHide = toolbar.offsetHeight || header.offsetHeight || 56;
+
+    let ticking = false;
+    let lastScrollY = window.scrollY;
+    let currentOffset = 0;
+
+    // NEW
+    let accumulatedDelta = 0;
+    const threshold = maxHide; // Minimum scroll delta before reacting, this helps to prevent jitter on small scrolls. Defaults to header height;
+
+    const updateHeaderVisibility = () => {
+      ticking = false;
+
+      const scrollY = window.scrollY;
+      const delta = scrollY - lastScrollY;
+      lastScrollY = scrollY;
+
+      // accumulate movement
+      accumulatedDelta += delta;
+
+      const shouldReact = Math.abs(accumulatedDelta) >= threshold;
+
+      // only react if threshold is exceeded
+      if (!shouldReact) return;
+
+      // apply only the accumulated movement
+      currentOffset += accumulatedDelta;
+      // reset accumulator AFTER applying
+      accumulatedDelta = 0;
+
+      currentOffset = Math.max(0, Math.min(currentOffset, maxHide));
+
+      if (scrollY <= 0) currentOffset = 0;
+
+      const progress = currentOffset / maxHide;
+
+      toolbar.style.transform = `translateY(-${currentOffset}px)`;
+      toolbar.style.opacity = `${1 - progress}`;
+
+      header.classList.toggle('scroll-hide', currentOffset > 0);
+      header.style.setProperty('--header-hide-progress', `${progress}`);
+    };
+
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(updateHeaderVisibility);
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    updateHeaderVisibility();
+
+    this._onWindowScrollHideHeader?.();
+    this._onWindowScrollHideHeader = () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  }
+
   private async _watchEditLegacySidebar(): Promise<void> {
     if (!this._hasSidebarConfig) return;
 
@@ -295,6 +372,7 @@ export class SidebarOrganizer {
     if (this._notCompatible) return;
 
     const panelResolver = (await this._panelResolver.element) as PartialPanelResolver;
+    this._watchScrollHideHeader();
     if (!panelResolver.route) return;
     const pathName = panelResolver.route?.path ?? window.location.pathname;
     if (!pathName) return;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -194,4 +194,8 @@ export interface SidebarConfig extends SidebardPanelConfig, SidebarAppearanceCon
    */
   uncategorized_items?: boolean | string[];
   visibility_templates?: VisibilityTemplateConfig;
+  /**
+   * Hide header when scrolling down and show it when scrolling up. This is a personal feature for the developer and not mentioned in the readme as it is not a core part of the plugin.
+   */
+  scroll_hide_header?: boolean;
 }


### PR DESCRIPTION
Introduce a feature that hides the header in lovelace dashboard when scrolling down and reveals it when scrolling up. This functionality can be enabled by setting `scroll_hide_header: true` in the configuration. 