### PR TITLE
Fix checking if config file should be used.

### DIFF
--- a/src/utilities/storage-utils.ts
+++ b/src/utilities/storage-utils.ts
@@ -23,7 +23,7 @@ export const getHiddenPanels = (): string[] => {
 
 export const sidebarUseConfigFile = (): boolean => {
   const useJson = window.localStorage.getItem(STORAGE.USE_CONFIG_FILE) || '""';
-  return JSON.parse(useJson) === 'true';
+  return JSON.parse(useJson) === true;
 };
 
 export const getStorageConfig = (): SidebarConfig | undefined => {


### PR DESCRIPTION
`JSON.parse("true")` returns a boolean type not a string, so `true === 'true'` will always evaluate to false.

Found this issue while investigating: https://github.com/ngocjohn/sidebar-organizer/issues/98#issuecomment-4175839305