### PR TITLE
fix: resolve infinite reload loop + group separator + configurable CSS vars

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -28,4 +28,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sidebar-organizer-fixed
-          path: dist/sidebar-organizer.js
+          path: build/sidebar-organizer.js

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,31 @@
+name: Build Artifact
+
+on:
+  push:
+    branches:
+      - fix/panel-reload-loop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm run rollup
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sidebar-organizer-fixed
+          path: dist/sidebar-organizer.js

--- a/src/components/editor/forms/header-schema.ts
+++ b/src/components/editor/forms/header-schema.ts
@@ -28,6 +28,11 @@ const BOOLEAN_OPTIONS = [
     name: 'force_transparent_background',
     helper: 'Force apply transparent background (fully transparent)',
   },
+  {
+    name: 'accordion_mode',
+    label: 'Accordion Mode',
+    helper: 'Only one group can be open at a time',
+  },
 ];
 
 const commonBooleanSchema = (name?: BooleanItem['name'][]) => {
@@ -88,7 +93,7 @@ export const BASE_APPEARANCE_SCHEMA = memoizeOne((data: SidebarAppearanceConfig)
                   },
                 ]
               : []),
-            ...commonBooleanSchema(['move_settings_from_fixed', 'force_transparent_background']),
+            ...commonBooleanSchema(['move_settings_from_fixed', 'force_transparent_background', 'accordion_mode']),
             {
               name: 'text_transformation',
               label: 'Text Transformation',

--- a/src/components/sidebar-dialog.ts
+++ b/src/components/sidebar-dialog.ts
@@ -632,40 +632,31 @@ export class SidebarConfigDialog extends BaseEditor {
 
     const { added, removed } = await comparePanelItems(this.hass, allPanels);
     if (Boolean(added.length || removed.length)) {
-      // If there are changes, persist them first, then update the sidebar items
+      // Silently merge panel changes into storage without requiring reload
       console.log('Storage panels have changes compared to current panels:', { added, removed });
 
-      // Merge added panels into stored panel order so they are not re-detected as new
+      let updatedOrder = [...currentPanelOrder];
+      let updatedHidden = [...hiddenItems];
+
+      // Merge added panels into stored panel order
       if (added.length > 0) {
-        const updatedOrder = [...currentPanelOrder, ...added];
-        setStorage(STORAGE.PANEL_ORDER, updatedOrder);
-        console.log('Persisted new panels to panel order:', added);
+        updatedOrder = [...updatedOrder, ...added];
       }
       // Remove panels that are no longer shown in sidebar
       if (removed.length > 0) {
         const removedSet = new Set(removed);
-        const filteredOrder = currentPanelOrder.filter((item: string) => !removedSet.has(item));
-        setStorage(STORAGE.PANEL_ORDER, filteredOrder);
-        const updatedHidden = [...new Set([...hiddenItems, ...removed])];
+        updatedOrder = updatedOrder.filter((item: string) => !removedSet.has(item));
+        updatedHidden = [...new Set([...updatedHidden, ...removed])];
         setStorage(STORAGE.HIDDEN_PANELS, updatedHidden);
-        console.log('Moved removed panels to hidden:', removed);
       }
 
-      const mesg =
-        added.length > 0
-          ? `New panels added: ${added.map((panel) => this.hass.panels[panel]?.title || panel).join(', ')}. `
-          : '';
-      const mesg2 =
-        removed.length > 0
-          ? `Panels not show in sidebar: ${removed.map((panel) => this.hass.panels[panel]?.title || panel).join(', ')}. `
-          : '';
-      const alertMesg = `Panels have changed since last configuration: ${mesg}${mesg2}
-      Reload sidebar configuration to update panels.`;
-      await this._alert(alertMesg, 'Reload page').then(() => {
-        this._mainDialog.closeDialog();
-        // Reload the page to update the panels
-        window.location.reload();
-      });
+      setStorage(STORAGE.PANEL_ORDER, updatedOrder);
+
+      // Continue with updated data instead of reloading
+      this._sidebarConfig = getStorageConfig() || {};
+      removeStorage(STORAGE.HIDDEN_PANELS);
+      this._updateSidebarItems(updatedOrder, updatedHidden);
+      return;
     } else {
       //success
       console.log(

--- a/src/components/sidebar-dialog.ts
+++ b/src/components/sidebar-dialog.ts
@@ -549,7 +549,7 @@ export class SidebarConfigDialog extends BaseEditor {
               @change=${(ev: Event) => {
                 const checked = (ev.target as HTMLInputElement).checked;
                 this._useConfigFile = checked;
-                setStorage(STORAGE.USE_CONFIG_FILE, checked.toString());
+                setStorage(STORAGE.USE_CONFIG_FILE, checked);
               }}
             ></ha-switch>
           </ha-formfield>
@@ -726,7 +726,7 @@ export class SidebarConfigDialog extends BaseEditor {
           this._invalidConfig = undefined;
           this._useConfigFile = false;
           this._mainDialog._configValid = true;
-          setStorage(STORAGE.USE_CONFIG_FILE, 'false');
+          setStorage(STORAGE.USE_CONFIG_FILE, false);
           setStorage(STORAGE.UI_CONFIG, this._sidebarConfig);
           this.requestUpdate();
         }

--- a/src/components/sidebar-dialog.ts
+++ b/src/components/sidebar-dialog.ts
@@ -632,8 +632,25 @@ export class SidebarConfigDialog extends BaseEditor {
 
     const { added, removed } = await comparePanelItems(this.hass, allPanels);
     if (Boolean(added.length || removed.length)) {
-      // If there are changes, update the sidebar items
+      // If there are changes, persist them first, then update the sidebar items
       console.log('Storage panels have changes compared to current panels:', { added, removed });
+
+      // Merge added panels into stored panel order so they are not re-detected as new
+      if (added.length > 0) {
+        const updatedOrder = [...currentPanelOrder, ...added];
+        setStorage(STORAGE.PANEL_ORDER, updatedOrder);
+        console.log('Persisted new panels to panel order:', added);
+      }
+      // Remove panels that are no longer shown in sidebar
+      if (removed.length > 0) {
+        const removedSet = new Set(removed);
+        const filteredOrder = currentPanelOrder.filter((item: string) => !removedSet.has(item));
+        setStorage(STORAGE.PANEL_ORDER, filteredOrder);
+        const updatedHidden = [...new Set([...hiddenItems, ...removed])];
+        setStorage(STORAGE.HIDDEN_PANELS, updatedHidden);
+        console.log('Moved removed panels to hidden:', removed);
+      }
+
       const mesg =
         added.length > 0
           ? `New panels added: ${added.map((panel) => this.hass.panels[panel]?.title || panel).join(', ')}. `
@@ -646,7 +663,7 @@ export class SidebarConfigDialog extends BaseEditor {
       Reload sidebar configuration to update panels.`;
       await this._alert(alertMesg, 'Reload page').then(() => {
         this._mainDialog.closeDialog();
-        // Reload the page to update the panels, to initial page
+        // Reload the page to update the panels
         window.location.reload();
       });
     } else {

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -228,6 +228,9 @@ export const DIVIDER_ADDED_STYLE = css`
     background-color: rgb(from var(--sidebar-selected-icon-color) r g b / 0.2);
   }
 
+  :host([expanded]) ha-md-list-item[group] {
+    padding-left: 20px !important;
+  }
   :host ha-md-list-item:has([group]) {
     transition: all;
   }

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -178,13 +178,13 @@ export const DIVIDER_ADDED_STYLE = css`
   }
 
   :host .divider[added] .added-content span {
-    transform: translateX(30px);
+    transform: translateX(var(--so-group-header-expanded-shift, 30px));
   }
   :host .divider[added]:hover .added-content.collapsed > span {
     transform: translateX(var(--so-group-header-hover-shift, 10px));
   }
   :host .divider[added] .added-content.collapsed > span {
-    transform: translateX(10px);
+    transform: translateX(var(--so-group-header-collapsed-shift, 10px));
   }
 
   :host([expanded]) .ha-scrollbar .divider[added]::before {

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -180,9 +180,6 @@ export const DIVIDER_ADDED_STYLE = css`
   :host .divider[added] .added-content span {
     transform: translateX(30px);
   }
-  :host .divider[added]:hover .added-content.collapsed > span {
-    transform: translateX(30px);
-  }
   :host .divider[added] .added-content.collapsed > span {
     transform: translateX(10px);
   }
@@ -229,7 +226,7 @@ export const DIVIDER_ADDED_STYLE = css`
   }
 
   :host([expanded]) ha-md-list-item[group] {
-    padding-left: 20px !important;
+    padding-left: var(--so-group-item-indent, 0px) !important;
   }
   :host ha-md-list-item:has([group]) {
     transition: all;

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -180,6 +180,9 @@ export const DIVIDER_ADDED_STYLE = css`
   :host .divider[added] .added-content span {
     transform: translateX(30px);
   }
+  :host .divider[added]:hover .added-content.collapsed > span {
+    transform: translateX(var(--so-group-header-hover-shift, 10px));
+  }
   :host .divider[added] .added-content.collapsed > span {
     transform: translateX(10px);
   }

--- a/src/sidebar-css.ts
+++ b/src/sidebar-css.ts
@@ -240,6 +240,7 @@ export const DIVIDER_ADDED_STYLE = css`
 
   :host([expanded]) ha-md-list-item[group] {
     padding-left: var(--so-group-item-indent, 0px) !important;
+    padding-inline-start: var(--so-group-item-indent, 0px) !important;
   }
   :host ha-md-list-item:has([group]) {
     transition: all;

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -763,7 +763,6 @@ export class SidebarOrganizer {
         if (groupName === PANEL_TYPE.UNCATEGORIZED_ITEMS) return; // Skip uncategorized group as it's not an actual group but a placeholder for ungrouped items
         const groupVisibilityTemplate = groupVisibilityMap.has(groupName) ? groupVisibilityMap.get(groupName)! : null;
         const isCollapsed = this.collapsedItems.has(groupName);
-        let lastGroupItem: Element | null = null;
         panels.forEach((panelId, index) => {
           const item = Array.from(topItems).find((el) => el.getAttribute(ATTRIBUTE.DATA_PANEL) === panelId);
           if (item) {
@@ -775,15 +774,8 @@ export class SidebarOrganizer {
               item.insertAdjacentElement('beforebegin', groupDivider);
             }
             item.classList.toggle(CLASS.COLLAPSED, isCollapsed);
-            lastGroupItem = item;
           }
         });
-        // Insert a closing divider after the last item in this group
-        // to visually separate grouped items from ungrouped items below
-        if (lastGroupItem) {
-          const closingDivider = this._createDivider(ATTRIBUTE.UNGROUPED);
-          (lastGroupItem as Element).insertAdjacentElement('afterend', closingDivider);
-        }
       });
 
       const firstUngroupedItem = topItemsContainer.querySelector(

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -1294,17 +1294,6 @@ export class SidebarOrganizer {
     }
 
     const isCollapsed = items[0].classList.contains(CLASS.COLLAPSED);
-
-    // Accordion mode: collapse all other groups when opening one
-    if (this._config?.accordion_mode && isCollapsed) {
-      const allGroups = Object.keys(this._config?.custom_groups || {});
-      allGroups.forEach((otherGroup) => {
-        if (otherGroup !== group && !this.collapsedItems.has(otherGroup)) {
-          this._collapseGroup(otherGroup, noAnimation, animationDelay);
-        }
-      });
-    }
-
     this._setItemToLocalStorage(group!, !isCollapsed);
 
     // Toggle collapsed state for group and its items
@@ -1330,35 +1319,6 @@ export class SidebarOrganizer {
         },
         { once: true }
       );
-    });
-  }
-
-  private _collapseGroup(group: string, noAnimation: boolean, animationDelay: number) {
-    const items = Array.from(this._scrollbarItems).filter((item) => {
-      return item.getAttribute('group') === group && !item.hasAttribute('moved');
-    }) as HTMLElement[];
-    if (!items.length) return;
-
-    this._setItemToLocalStorage(group, true);
-
-    // Update divider state
-    const divider = this._scrollbar.querySelector(`${SELECTOR.DIVIDER_ADDED}[${ATTRIBUTE.GROUP}="${group}"]`);
-    if (divider) {
-      divider.classList.add(CLASS.COLLAPSED);
-      divider.querySelector(SELECTOR.ADDED_CONTENT)?.classList.add(CLASS.COLLAPSED);
-    }
-
-    if (noAnimation) {
-      items.forEach((item) => item.classList.add(CLASS.COLLAPSED));
-      return;
-    }
-    items.forEach((item, index) => {
-      item.style.animationDelay = `${index * animationDelay}ms`;
-      item.classList.add('slideOut');
-      item.addEventListener('animationend', () => {
-        item.classList.add(CLASS.COLLAPSED);
-        item.classList.remove('slideOut');
-      }, { once: true });
     });
   }
 

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -1392,6 +1392,32 @@ export class SidebarOrganizer {
     }
 
     const isCollapsed = items[0].classList.contains(CLASS.COLLAPSED);
+
+    // Accordion mode: collapse all other groups when expanding one
+    if (this._config?.accordion_mode && isCollapsed && this.setupConfigDone) {
+      const allGroups = Object.keys(this._config?.custom_groups || {});
+      allGroups.forEach((otherGroup) => {
+        if (otherGroup !== group && !this.collapsedItems.has(otherGroup)) {
+          const otherItems = Array.from(this._scrollbarItems).filter((item) => {
+            return item.getAttribute('group') === otherGroup && !item.hasAttribute('moved');
+          }) as HTMLElement[];
+          if (!otherItems.length) return;
+
+          this._setItemToLocalStorage(otherGroup, true);
+
+          const divider = this._scrollbar.querySelector(
+            `${SELECTOR.DIVIDER_ADDED}[${ATTRIBUTE.GROUP}="${otherGroup}"]`
+          );
+          if (divider) {
+            divider.classList.add(CLASS.COLLAPSED);
+            divider.querySelector(SELECTOR.ADDED_CONTENT)?.classList.add(CLASS.COLLAPSED);
+          }
+
+          otherItems.forEach((item) => item.classList.add(CLASS.COLLAPSED));
+        }
+      });
+    }
+
     this._setItemToLocalStorage(group!, !isCollapsed);
 
     // Toggle collapsed state for group and its items

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -1294,6 +1294,17 @@ export class SidebarOrganizer {
     }
 
     const isCollapsed = items[0].classList.contains(CLASS.COLLAPSED);
+
+    // Accordion mode: collapse all other groups when opening one
+    if (this._config?.accordion_mode && isCollapsed) {
+      const allGroups = Object.keys(this._config?.custom_groups || {});
+      allGroups.forEach((otherGroup) => {
+        if (otherGroup !== group && !this.collapsedItems.has(otherGroup)) {
+          this._collapseGroup(otherGroup, noAnimation, animationDelay);
+        }
+      });
+    }
+
     this._setItemToLocalStorage(group!, !isCollapsed);
 
     // Toggle collapsed state for group and its items
@@ -1319,6 +1330,35 @@ export class SidebarOrganizer {
         },
         { once: true }
       );
+    });
+  }
+
+  private _collapseGroup(group: string, noAnimation: boolean, animationDelay: number) {
+    const items = Array.from(this._scrollbarItems).filter((item) => {
+      return item.getAttribute('group') === group && !item.hasAttribute('moved');
+    }) as HTMLElement[];
+    if (!items.length) return;
+
+    this._setItemToLocalStorage(group, true);
+
+    // Update divider state
+    const divider = this._scrollbar.querySelector(`${SELECTOR.DIVIDER_ADDED}[${ATTRIBUTE.GROUP}="${group}"]`);
+    if (divider) {
+      divider.classList.add(CLASS.COLLAPSED);
+      divider.querySelector(SELECTOR.ADDED_CONTENT)?.classList.add(CLASS.COLLAPSED);
+    }
+
+    if (noAnimation) {
+      items.forEach((item) => item.classList.add(CLASS.COLLAPSED));
+      return;
+    }
+    items.forEach((item, index) => {
+      item.style.animationDelay = `${index * animationDelay}ms`;
+      item.classList.add('slideOut');
+      item.addEventListener('animationend', () => {
+        item.classList.add(CLASS.COLLAPSED);
+        item.classList.remove('slideOut');
+      }, { once: true });
     });
   }
 

--- a/src/sidebar-organizer.ts
+++ b/src/sidebar-organizer.ts
@@ -674,6 +674,7 @@ export class SidebarOrganizer {
         if (groupName === PANEL_TYPE.UNCATEGORIZED_ITEMS) return; // Skip uncategorized group as it's not an actual group but a placeholder for ungrouped items
         const groupVisibilityTemplate = groupVisibilityMap.has(groupName) ? groupVisibilityMap.get(groupName)! : null;
         const isCollapsed = this.collapsedItems.has(groupName);
+        let lastGroupItem: Element | null = null;
         panels.forEach((panelId, index) => {
           const item = Array.from(topItems).find((el) => el.getAttribute(ATTRIBUTE.DATA_PANEL) === panelId);
           if (item) {
@@ -685,8 +686,15 @@ export class SidebarOrganizer {
               item.insertAdjacentElement('beforebegin', groupDivider);
             }
             item.classList.toggle(CLASS.COLLAPSED, isCollapsed);
+            lastGroupItem = item;
           }
         });
+        // Insert a closing divider after the last item in this group
+        // to visually separate grouped items from ungrouped items below
+        if (lastGroupItem) {
+          const closingDivider = this._createDivider(ATTRIBUTE.UNGROUPED);
+          (lastGroupItem as Element).insertAdjacentElement('afterend', closingDivider);
+        }
       });
 
       const firstUngroupedItem = topItemsContainer.querySelector(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,7 +121,6 @@ export interface SidebarAppearanceConfig {
   hide_header_toggle?: boolean;
   animation_off?: boolean;
   animation_delay?: number;
-  accordion_mode?: boolean;
   text_transformation?: TextTransformation;
   move_settings_from_fixed?: boolean;
   force_transparent_background?: boolean;
@@ -131,7 +130,6 @@ export const AppearanceConfigKeys = [
   'hide_header_toggle',
   'animation_off',
   'animation_delay',
-  'accordion_mode',
   'text_transformation',
   'move_settings_from_fixed',
   'force_transparent_background',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,7 @@ export interface SidebarAppearanceConfig {
   hide_header_toggle?: boolean;
   animation_off?: boolean;
   animation_delay?: number;
+  accordion_mode?: boolean;
   text_transformation?: TextTransformation;
   move_settings_from_fixed?: boolean;
   force_transparent_background?: boolean;
@@ -130,6 +131,7 @@ export const AppearanceConfigKeys = [
   'hide_header_toggle',
   'animation_off',
   'animation_delay',
+  'accordion_mode',
   'text_transformation',
   'move_settings_from_fixed',
   'force_transparent_background',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,7 @@ export interface SidebarAppearanceConfig {
   hide_header_toggle?: boolean;
   animation_off?: boolean;
   animation_delay?: number;
+  accordion_mode?: boolean;
   text_transformation?: TextTransformation;
   move_settings_from_fixed?: boolean;
   force_transparent_background?: boolean;
@@ -131,6 +132,7 @@ export const AppearanceConfigKeys = [
   'hide_header_toggle',
   'animation_off',
   'animation_delay',
+  'accordion_mode',
   'text_transformation',
   'move_settings_from_fixed',
   'force_transparent_background',

--- a/src/utilities/model/store.ts
+++ b/src/utilities/model/store.ts
@@ -6,7 +6,7 @@ import { DashboardPanels, DataTableItem } from '@utilities/dashboard';
 import { nextRender } from '@utilities/dom-utils';
 import { UTILITIES } from '@utilities/index';
 import { shallowEqual } from '@utilities/shallow-equal';
-import { setStorage } from '@utilities/storage-utils';
+import { getStorage, setStorage } from '@utilities/storage-utils';
 import { showToast } from '@utilities/toast-notify';
 import { isEmpty } from 'es-toolkit/compat';
 
@@ -101,8 +101,10 @@ export default class Store {
     if (!this._panelHasChanged || !this._dashboardPanels) {
       return shouldReload;
     }
-    const { notShowInSidebar, removed } = this._dashboardPanels;
+    const { notShowInSidebar, removed, added } = this._dashboardPanels;
     const configHelper = this._utils.CONFIG;
+
+    // Handle removed panels
     const itemToRemove = new Set([...(removed || []), ...(notShowInSidebar?.map((item) => item.url_path) || [])]);
     if (itemToRemove.size !== 0) {
       const config = { ...this._organizer._config };
@@ -125,6 +127,25 @@ export default class Store {
         );
       }
     }
+
+    // Handle added panels — merge into stored panel order so they are not re-detected as new
+    if (added && added.length > 0) {
+      const currentOrder: string[] = JSON.parse(getStorage(STORAGE.PANEL_ORDER) || '[]');
+      const addedPaths = added.map((item) => item.url_path);
+      const newPaths = addedPaths.filter((path) => !currentOrder.includes(path));
+      if (newPaths.length > 0) {
+        const updatedOrder = [...currentOrder, ...newPaths];
+        setStorage(STORAGE.PANEL_ORDER, updatedOrder);
+        console.debug(
+          '%cSTORE:',
+          'color: #4dabf7;',
+          'Added new panels to stored panel order:',
+          newPaths
+        );
+        shouldReload = true;
+      }
+    }
+
     return shouldReload;
   };
 
@@ -140,7 +161,10 @@ export default class Store {
       message: `${NAMESPACE.toUpperCase()}: Changes detected in sidebar panels. Reload page to apply changes.`,
       action: {
         text: 'Reload',
-        action: () => this._organizer._reloadWindow(),
+        action: async () => {
+          await this._shouldUpdateConfig();
+          this._organizer._reloadWindow();
+        },
       },
       duration: -1,
       dismissable: false,

--- a/src/utilities/model/store.ts
+++ b/src/utilities/model/store.ts
@@ -131,17 +131,12 @@ export default class Store {
     // Handle added panels — merge into stored panel order so they are not re-detected as new
     if (added && added.length > 0) {
       const currentOrder: string[] = JSON.parse(getStorage(STORAGE.PANEL_ORDER) || '[]');
-      const addedPaths = added.map((item) => item.url_path);
+      const addedPaths = added.map((item) => item.url_path!);
       const newPaths = addedPaths.filter((path) => !currentOrder.includes(path));
       if (newPaths.length > 0) {
         const updatedOrder = [...currentOrder, ...newPaths];
         setStorage(STORAGE.PANEL_ORDER, updatedOrder);
-        console.debug(
-          '%cSTORE:',
-          'color: #4dabf7;',
-          'Added new panels to stored panel order:',
-          newPaths
-        );
+        console.debug('%cSTORE:', 'color: #4dabf7;', 'Added new panels to stored panel order:', newPaths);
         shouldReload = true;
       }
     }

--- a/src/utilities/storage-utils.ts
+++ b/src/utilities/storage-utils.ts
@@ -23,7 +23,7 @@ export const getHiddenPanels = (): string[] => {
 
 export const sidebarUseConfigFile = (): boolean => {
   const useJson = window.localStorage.getItem(STORAGE.USE_CONFIG_FILE) || '""';
-  return JSON.parse(useJson) === 'true';
+  return JSON.parse(useJson) === true;
 };
 
 export const getStorageConfig = (): SidebarConfig | undefined => {


### PR DESCRIPTION
## Summary

- **Fix infinite reload loop when new panels are added** (#98): `_validateStoragePanels()` detected new panels but never persisted them before calling `window.location.reload()`, causing an endless loop. Now silently merges added panels into the stored panel order and continues without reload.
- **Fix `sidebarUseConfigFile()` boolean comparison bug**: Both the reader and writer sides are now fixed. Writer stored `checked.toString()` (a string), but reader compared with `=== true` (boolean). Now `setStorage()` stores a real boolean so `JSON.parse() === true` works correctly.
- **Fix `_shouldUpdateConfig()` ignoring added panels**: Only handled removed panels. Now also merges added panels into `STORAGE.PANEL_ORDER`.
- **Fix `_needReloadToast()` not persisting before reload**: Reload action now calls `_shouldUpdateConfig()` before `window.location.reload()`.
- **Visual separator for ungrouped items**: Existing `firstUngroupedItem` divider logic handles separation correctly (removed redundant per-group closing divider from earlier revision based on review feedback).
- **Add configurable CSS variables for group styling**:
  - `--so-group-item-indent` (default: `0px`) — indent items inside groups (with `padding-inline-start` for RTL support)
  - `--so-group-header-expanded-shift` (default: `30px`) — header text position when expanded
  - `--so-group-header-collapsed-shift` (default: `10px`) — header text position when collapsed  
  - `--so-group-header-hover-shift` (default: `10px`) — header text position on hover (collapsed)

  Set all `*-shift` vars to the same value to prevent text jumping on expand/collapse/hover.

- **Add accordion mode**: New `accordion_mode` setting in Appearance Settings. When enabled, opening a group automatically collapses all others. Available as a UI toggle and via config (`accordion_mode: true`). Guarded to prevent firing during initial load.

## Test plan

- [ ] Add new dashboards, open Sidebar Organizer settings → no reload loop
- [ ] Create groups with some items ungrouped → ungrouped items visually separated (single divider, no duplicates)
- [ ] Set `--so-group-item-indent: 20px` in custom styles → grouped items indented
- [ ] Set all `--so-group-header-*-shift` to `10px` → no text jumping
- [ ] Verify collapsed/expanded groups still work correctly
- [ ] Enable accordion mode via Appearance Settings toggle → only one group open at a time
- [ ] Disable accordion mode → multiple groups can be open simultaneously
- [ ] Reload page with accordion mode enabled → groups stay as they were (no init side effects)
- [ ] Toggle "Use Config File" switch → setting persists correctly (boolean, not string)

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)